### PR TITLE
blocking or non-blocking logger, gated by features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,9 @@ name = "traccia"
 version = "0.1.0"
 edition = "2024"
 
+
 [dependencies]
 dyn-clone = "1.0.18"
+
+[features]
+blocking = []

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -18,6 +18,4 @@ fn main() {
     for handle in handles {
         handle.join().unwrap();
     }
-
-    traccia::shutdown();
 }

--- a/src/impl/async.rs
+++ b/src/impl/async.rs
@@ -1,0 +1,106 @@
+use std::{
+    sync::{Mutex, mpsc},
+    thread,
+};
+
+use crate::{Config, DefaultFormatter, Formatter, Logger, Record, Target, logger};
+
+enum ChannelMessage {
+    Log(String),
+    Flush,
+}
+
+pub struct DefaultLogger {
+    config: Config,
+    sender: mpsc::Sender<ChannelMessage>,
+    worker: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+impl DefaultLogger {
+    pub fn new(config: Config) -> Self {
+        let (sender, receiver) = mpsc::channel();
+
+        let thread_targerts = dyn_clone::clone_box(&config.targets);
+        let worker = std::thread::spawn(move || {
+            Self::worker_thread(receiver, *thread_targerts);
+        });
+
+        DefaultLogger {
+            config,
+            sender,
+            worker: Mutex::new(Some(worker)),
+        }
+    }
+
+    fn worker_thread(receiver: mpsc::Receiver<ChannelMessage>, targets: Vec<Box<dyn Target>>) {
+        loop {
+            match receiver.recv() {
+                Ok(ChannelMessage::Log(formatted)) => {
+                    for target in &targets {
+                        if let Err(e) = target.write(&formatted) {
+                            eprintln!("Failed to write to target: {}", e);
+                        }
+                    }
+                }
+
+                Ok(ChannelMessage::Flush) => break,
+
+                Err(_) => break,
+            }
+        }
+
+        // Drain the remaining messages
+        while let Ok(message) = receiver.try_recv() {
+            match message {
+                ChannelMessage::Log(formatted) => {
+                    for target in &targets {
+                        if let Err(e) = target.write(&formatted) {
+                            eprintln!("Failed to write to target: {}", e);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Logger for DefaultLogger {
+    fn enabled(&self, level: crate::LogLevel) -> bool {
+        self.config.level <= level
+    }
+
+    fn abort(&self) {
+        let _ = self.sender.send(ChannelMessage::Flush);
+        if let Ok(mut handle) = self.worker.lock() {
+            if let Some(handle) = handle.take() {
+                handle.join().unwrap();
+            }
+        }
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.level) {
+            return;
+        }
+
+        let formatted = match &self.config.format {
+            Some(formatter) => formatter.format(record),
+            None => DefaultFormatter.format(record),
+        };
+
+        let _ = self.sender.send(ChannelMessage::Log(formatted));
+    }
+}
+
+impl Default for DefaultLogger {
+    fn default() -> Self {
+        DefaultLogger::new(Config::default())
+    }
+}
+
+pub fn shutdown() {
+    if let Ok(logger) = logger() {
+        logger.abort();
+    }
+}

--- a/src/impl/blocking.rs
+++ b/src/impl/blocking.rs
@@ -1,0 +1,42 @@
+use crate::{Config, DefaultFormatter, Formatter, Logger, Record};
+
+pub struct DefaultLogger {
+    config: Config,
+}
+
+impl DefaultLogger {
+    pub fn new(config: Config) -> Self {
+        DefaultLogger { config }
+    }
+}
+
+impl Logger for DefaultLogger {
+    fn enabled(&self, level: crate::LogLevel) -> bool {
+        self.config.level <= level
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.level) {
+            return;
+        }
+
+        let formatted = match &self.config.format {
+            Some(formatter) => formatter.format(record),
+            None => DefaultFormatter.format(record),
+        };
+
+        for target in &self.config.targets {
+            if let Err(e) = target.write(&formatted) {
+                eprintln!("Failed to write to target: {}", e);
+            }
+        }
+    }
+}
+
+impl Default for DefaultLogger {
+    fn default() -> Self {
+        DefaultLogger {
+            config: Config::default(),
+        }
+    }
+}

--- a/src/impl/mod.rs
+++ b/src/impl/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(not(feature = "blocking"))]
+pub mod r#async;
+
+#[cfg(feature = "blocking")]
+pub mod blocking;

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,0 +1,34 @@
+use crate::{Color, Colorize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogLevel::Trace => write!(f, "TRACE"),
+            LogLevel::Debug => write!(f, "DEBUG"),
+            LogLevel::Info => write!(f, "INFO"),
+            LogLevel::Warn => write!(f, "WARN"),
+            LogLevel::Error => write!(f, "ERROR"),
+        }
+    }
+}
+
+impl LogLevel {
+    pub fn default_coloring(&self) -> String {
+        match self {
+            LogLevel::Trace => format!("{}", self).color(Color::Cyan),
+            LogLevel::Debug => format!("{}", self).color(Color::Blue),
+            LogLevel::Info => format!("{}", self).color(Color::Green),
+            LogLevel::Warn => format!("{}", self).color(Color::Yellow),
+            LogLevel::Error => format!("{}", self).color(Color::Red),
+        }
+    }
+}


### PR DESCRIPTION
By default the logger implementation will be non-blocking. The logging operations, (writing to file, etc.) will be done on a secondary thread.
This will mean that there will be a need for synchronization at the end of the program, since some threads could still be performing operations, hence the need for the `shutdown` function

The user can also choose a non-blocking default implementation, enabling the `blocking feature`.