### PR TITLE
remove dyn-clone dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,5 @@
 version = 4
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
-
-[[package]]
 name = "traccia"
 version = "0.1.0"
-dependencies = [
- "dyn-clone",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,5 @@ name = "traccia"
 version = "0.1.0"
 edition = "2024"
 
-
-[dependencies]
-dyn-clone = "1.0.18"
-
 [features]
 blocking = []

--- a/src/impl/async.rs
+++ b/src/impl/async.rs
@@ -20,9 +20,9 @@ impl DefaultLogger {
     pub fn new(config: Config) -> Self {
         let (sender, receiver) = mpsc::channel();
 
-        let thread_targerts = dyn_clone::clone_box(&config.targets);
+        let thread_targerts = config.targets.clone();
         let worker = std::thread::spawn(move || {
-            Self::worker_thread(receiver, *thread_targerts);
+            Self::worker_thread(receiver, thread_targerts);
         });
 
         DefaultLogger {


### PR DESCRIPTION
Implement a workaround to be able to clone boxed trait object, used in the async logger to share targets through threads, and removing a dependency.