### PR TITLE
v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+All the dates in this changelog are formatted as day/month/year.
+
 # 0.2.0 - 3/3/2025
 
 - Added `Debug, Clone, Copy, PartialEq, Eq` to `Color`.
@@ -19,3 +21,8 @@
 - Removed the docs folder from the package, that caused the size to go up to 450 KiB
 - Renamed CHANGELOG to CHANGELOG.md
 - Replaced `///` comments with `//!` comments in `lib.rs`
+
+# 1.2.2 - 4/3/2025
+
+- Removed the `flush` function and changed all examples accordingly.
+- Added a wrapper around libc's `atexit` to create a shutdown hook that flushes the log buffer automatically.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "traccia"
-version = "0.2.2"
+version = "1.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traccia"
-version = "0.2.2"
+version = "1.2.2"
 edition = "2024"
 authors = ["Saverio Scagnoli <svscagn@gmail.com>"]
 description = "A zero-dependency, flexible logging framework for Rust applications"
@@ -24,7 +24,6 @@ exclude = [
 [features]
 default = []
 blocking = []
-# No external dependencies by default, keeping it lightweight
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ A zero-dependency, all-in-one flexible logging framework for Rust applications.
   </div>
 </div>
 
-
-
-
 ## Overview
 
 This crate provides a configurable logging system that supports multiple output targets, customizable formatting, and different log levels. It can be used in both synchronous (blocking) and asynchronous contexts.
@@ -45,7 +42,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-traccia = "0.2.2"
+traccia = "1.2.2"
 ```
 
 ## Quick Start
@@ -174,9 +171,6 @@ init_with_config(config);
 This will be the default implementation.
 If you wish to change to a blocking logger,
 enable the `blocking` feature.
-
-NOTE: You must call the flush function in this mode, as the secondary thread needs to be notified to flush the buffer.
-
 ```rust
 use traccia::{init_with_config, Config, LogLevel};
 
@@ -186,9 +180,6 @@ fn main() {
 
     // Log messages
     info!("Async logging enabled");
-
-    // When application exits
-    traccia::flush();
 }
 ```
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -10,7 +10,4 @@ fn main() {
     info!("This is an info message");
     warn!("This is a warn message");
     error!("This is an error message");
-
-    #[cfg(not(feature = "blocking"))]
-    traccia::flush();
 }

--- a/examples/custom-format.rs
+++ b/examples/custom-format.rs
@@ -26,8 +26,4 @@ fn main() {
     info!("This is an info message");
     warn!("This is a warn message");
     error!("This is an error message");
-
-    // If not using the blocking feature, call `flush` function to flush the log buffer
-    #[cfg(not(feature = "blocking"))]
-    traccia::flush();
 }

--- a/examples/target.rs
+++ b/examples/target.rs
@@ -15,8 +15,4 @@ fn main() {
     info!("This is an info message");
     warn!("This is a warn message");
     error!("This is an error message");
-
-    // If not using the blocking feature, call `flush` function to flush the log buffer
-    #[cfg(not(feature = "blocking"))]
-    traccia::flush();
 }

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -38,8 +38,4 @@ fn main() {
     for handle in handles {
         handle.join().unwrap();
     }
-
-    // If not using the blocking feature, call `flush` function to flush the log buffer
-    #[cfg(not(feature = "blocking"))]
-    traccia::flush();
 }

--- a/src/impl/async.rs
+++ b/src/impl/async.rs
@@ -3,7 +3,7 @@ use std::{
     thread,
 };
 
-use crate::{Config, DefaultFormatter, Formatter, Logger, Record, Target, logger};
+use crate::{Config, DefaultFormatter, Formatter, Logger, Record, Target};
 
 enum ChannelMessage {
     Log(String),
@@ -96,11 +96,5 @@ impl Logger for DefaultLogger {
 impl Default for DefaultLogger {
     fn default() -> Self {
         DefaultLogger::new(Config::default())
-    }
-}
-
-pub fn flush() {
-    if let Ok(logger) = logger() {
-        logger.abort();
     }
 }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,0 +1,33 @@
+//! Simple wrapper around `atexit` to allow for a single function to be called when the program exits.
+//!
+//! Used for flushing logs and other cleanup tasks.
+
+use std::ffi::c_int;
+use std::sync::OnceLock;
+
+static HOOK: OnceLock<Option<Box<dyn Fn() + Send + Sync>>> = OnceLock::new();
+
+extern "C" fn shutdown_wrapper() {
+    if let Some(ref hook) = *HOOK.get().unwrap() {
+        hook();
+    }
+}
+
+unsafe extern "C" {
+    fn atexit(callback: extern "C" fn()) -> c_int;
+}
+
+pub fn add_hook<F>(cb: F) -> bool
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    let _ = HOOK.set(Some(Box::new(cb))).is_ok();
+
+    let result: c_int;
+
+    unsafe {
+        result = atexit(shutdown_wrapper);
+    }
+
+    result == 0
+}


### PR DESCRIPTION
Closes #4 

Opted for the `atexit` solution to keep things elegant. 