### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,9 @@ All the dates in this changelog are formatted as day/month/year.
 
 - Added the `Fatal` LogLevel variant, useful for logging errors that cause the program to stop.
 - Added the possibility to filter logs for specific targets (like only logging fatal errors to files.)
+
+# 2.0.0 - 4/4/2025
+
+- Added the `level` parameter to the `write` trait function for `Target`, which breaks current custom implementations.
+
+- Added the possibility to make console write to a custom output `stdout` or `stderr`, both globally and per-level.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "traccia"
-version = "1.4.2"
+version = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "traccia"
 version = "2.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["Saverio Scagnoli <svscagn@gmail.com>"]
 description = "A zero-dependency, flexible logging framework for Rust applications"
 documentation = "https://docs.rs/traccia"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traccia"
-version = "1.4.2"
+version = "2.0.0"
 edition = "2021"
 authors = ["Saverio Scagnoli <svscagn@gmail.com>"]
 description = "A zero-dependency, flexible logging framework for Rust applications"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-traccia = "1.4.2"
+traccia = "2.0.0"
 ```
 
 ## Quick Start

--- a/examples/filtered_output.rs
+++ b/examples/filtered_output.rs
@@ -1,0 +1,19 @@
+use traccia::{debug, error, fatal, info, Console, LogLevel, Output};
+
+fn main() {
+    traccia::init_with_config(traccia::Config {
+        level: LogLevel::Debug,
+        targets: vec![Box::new(
+            Console::new()
+                .filtered_output(LogLevel::Error, Output::Stderr)
+                .filtered_output(LogLevel::Fatal, Output::Stderr),
+        )],
+        ..Default::default()
+    });
+
+    debug!("This will be logged to stdout");
+    info!("In fact, only error and fatal messages will be logged to stderr.");
+
+    error!("This is an error logged to stderr!!!");
+    fatal!("This is a fatal error logged to stderr!!!");
+}

--- a/examples/output.rs
+++ b/examples/output.rs
@@ -1,0 +1,14 @@
+use traccia::{debug, error, fatal, info, Console, LogLevel, Output};
+
+fn main() {
+    traccia::init_with_config(traccia::Config {
+        level: LogLevel::Debug,
+        targets: vec![Box::new(Console::new().output(Output::Stderr))],
+        ..Default::default()
+    });
+
+    debug!("This will be logged to stderr.");
+    info!("In fact, all messages will be logged to stderr.");
+    error!("This is an error logged to stderr!!!");
+    fatal!("This is a fatal error logged to stderr!!!");
+}

--- a/src/impl/async.rs
+++ b/src/impl/async.rs
@@ -1,5 +1,5 @@
 use std::{
-    sync::{Mutex, mpsc},
+    sync::{mpsc, Mutex},
     thread,
 };
 
@@ -41,7 +41,7 @@ impl DefaultLogger {
                 }
             }
 
-            if let Err(e) = target.write(&formatted) {
+            if let Err(e) = target.write(level, &formatted) {
                 eprintln!("Failed to write to target: {}", e);
             }
         }

--- a/src/impl/blocking.rs
+++ b/src/impl/blocking.rs
@@ -27,12 +27,12 @@ impl Logger for DefaultLogger {
 
         for target in &self.config.targets {
             if let Some(filter_level) = target.filter_level() {
-                if level < filter_level {
+                if record.level < filter_level {
                     continue;
                 }
             }
 
-            if let Err(e) = target.write(&formatted) {
+            if let Err(e) = target.write(record.level, &formatted) {
                 eprintln!("Failed to write to target: {}", e);
             }
         }

--- a/src/level.rs
+++ b/src/level.rs
@@ -9,7 +9,7 @@ use crate::{Color, Colorize};
 /// - `Info`: General information about application progress
 /// - `Warn`: Potentially harmful situations that might need attention
 /// - `Error`: Error events that might still allow the application to continue running
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum LogLevel {
     /// Very detailed information for debugging specific issues
     Trace,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub use error::Error;
 pub use format::{DefaultFormatter, Formatter};
 pub use level::LogLevel;
 pub use strings::{Color, Colorize, Style};
-pub use target::{Console, File, FileMode, Target};
+pub use target::{Console, File, FileMode, Output, Target};
 
 #[cfg(feature = "blocking")]
 pub use r#impl::blocking::DefaultLogger;


### PR DESCRIPTION
Closes #10 

- Added the `level` parameter to the `write` trait function for `Target`, which breaks current custom implementations.

- Added the possibility to make console write to a custom output `stdout` or `stderr`, both globally and per-level.