### PR TITLE
v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,10 @@ All the dates in this changelog are formatted as day/month/year.
 - Added the `level` parameter to the `write` trait function for `Target`, which breaks current custom implementations.
 
 - Added the possibility to make console write to a custom output `stdout` or `stderr`, both globally and per-level.
+
+# 2.0.1 - 10/4/2025
+
+- Added `FromStr` implementation for `LogLevel`.
+- Added `TryFrom` implementation from `LogLevel` to `u8`.
+- Added `TryFrom` implementation from `u8` to `LogLevel`.
+- Added `Error::ParseLogLevel` to indicate whether these parsing methods fail.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "traccia"
-version = "2.0.0"
+version = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traccia"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 authors = ["Saverio Scagnoli <svscagn@gmail.com>"]
 description = "A zero-dependency, flexible logging framework for Rust applications"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-traccia = "2.0.0"
+traccia = "2.0.1"
 ```
 
 ## Quick Start

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,10 +2,16 @@ use std::{fmt::Display, io};
 
 #[derive(Debug)]
 pub enum Error {
+    /// Generic wrapper over io::Error
     Io(io::Error),
+    /// The logger requires to be initialized but it isn't
     NotInitialized,
+    /// The logger has been initialized more than once.
     AlreadyInitialized,
+    /// The mutex is poisoned (i.e. `File` targets)
     Poisoned,
+    /// Failed to convert `LogLevel` to something else or vice-versa
+    ParseLogLevel,
 }
 
 impl From<io::Error> for Error {
@@ -21,6 +27,7 @@ impl Display for Error {
             Error::NotInitialized => write!(f, "A logger has not been initialized"),
             Error::AlreadyInitialized => write!(f, "A logger has already been initialized"),
             Error::Poisoned => write!(f, "Mutex is poisoned"),
+            Error::ParseLogLevel => write!(f, "Could not parse log level from string"),
         }
     }
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 /// Log level definitions and utilities.
 use crate::{Color, Colorize};
 
@@ -64,6 +66,67 @@ impl LogLevel {
             LogLevel::Warn => format!("{}", self).color(Color::Yellow),
             LogLevel::Error => format!("{}", self).color(Color::Red),
             LogLevel::Fatal => format!("{}", self).color(Color::BrightRed),
+        }
+    }
+}
+
+/// The default log level is info
+impl Default for LogLevel {
+    fn default() -> Self {
+        LogLevel::Info
+    }
+}
+
+/// Parse the log level from &str.
+///
+/// Useful for things like clap to parse the log level via
+/// command-line arguments.
+impl FromStr for LogLevel {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "trace" => Ok(LogLevel::Trace),
+            "debug" => Ok(LogLevel::Debug),
+            "info" => Ok(LogLevel::Info),
+            "warn" => Ok(LogLevel::Warn),
+            "error" => Ok(LogLevel::Error),
+            "fatal" => Ok(LogLevel::Fatal),
+
+            _ => Err(crate::Error::ParseLogLevel),
+        }
+    }
+}
+
+/// Tryfrom u8 parsing implementation
+impl TryFrom<u8> for LogLevel {
+    type Error = crate::Error;
+
+    fn try_from(value: u8) -> Result<Self, crate::Error> {
+        match value {
+            0 => Ok(LogLevel::Trace),
+            1 => Ok(LogLevel::Debug),
+            2 => Ok(LogLevel::Info),
+            3 => Ok(LogLevel::Warn),
+            4 => Ok(LogLevel::Error),
+            5 => Ok(LogLevel::Fatal),
+            _ => Err(crate::Error::ParseLogLevel),
+        }
+    }
+}
+
+/// TryFrom log level implementation for u8
+impl TryFrom<LogLevel> for u8 {
+    type Error = crate::Error;
+
+    fn try_from(value: LogLevel) -> Result<Self, Self::Error> {
+        match value {
+            LogLevel::Trace => Ok(0),
+            LogLevel::Debug => Ok(1),
+            LogLevel::Info => Ok(2),
+            LogLevel::Warn => Ok(3),
+            LogLevel::Error => Ok(4),
+            LogLevel::Fatal => Ok(5),
         }
     }
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -92,7 +92,6 @@ impl FromStr for LogLevel {
             "warn" => Ok(LogLevel::Warn),
             "error" => Ok(LogLevel::Error),
             "fatal" => Ok(LogLevel::Fatal),
-
             _ => Err(crate::Error::ParseLogLevel),
         }
     }


### PR DESCRIPTION
- Added `FromStr` implementation for `LogLevel`.
- Added `TryFrom` implementation from `LogLevel` to `u8`.
- Added `TryFrom` implementation from `u8` to `LogLevel`.
- Added `Error::ParseLogLevel` to indicate whether these parsing methods fail.